### PR TITLE
add --database argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,3 +83,10 @@ Export full file URL:
 .. code-block:: bash
 
     ./manage.py dumpdata_one app_name.model_name --fields=image --full_url=image
+
+
+Export from another database than 'default':
+
+.. code-block:: bash
+
+    ./manage.py dumpdata_one app_name.model_name --database=other_database

--- a/src/django_dumpdata_one/management/commands/dumpdata_one.py
+++ b/src/django_dumpdata_one/management/commands/dumpdata_one.py
@@ -14,6 +14,7 @@ class Command(BaseCommand):
         parser.add_argument('--filter', type=str)
         parser.add_argument('--full_url', type=str)
         parser.add_argument('--limit', type=int)
+        parser.add_argument('--database', type=str)
 
     def handle(self, *args, **options):
 
@@ -23,6 +24,7 @@ class Command(BaseCommand):
         filters = self.get_filter_dict(options['filter'])
         full_urls = options['full_url']
         limit = options['limit']
+        database = options['database'] or 'default'
 
         Model = apps.get_model(app_model)
 
@@ -36,7 +38,7 @@ class Command(BaseCommand):
 
         full_urls = full_urls.split(',') if full_urls is not None else []
 
-        records = Model.objects.all()
+        records = Model.objects.using(database).all()
         if filters:
             records = records.filter(**filters)
 


### PR DESCRIPTION
Following the interface of django's [dumpdata](https://docs.djangoproject.com/en/3.2/ref/django-admin/#dumpdata), where you can add the argument `--database` to specify from which database the data should be dump

